### PR TITLE
Update mdBook version 0.4.5

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Setup mdBook
         uses: peaceiris/actions-mdbook@v1
         with:
-          mdbook-version: '0.4.4'
+          mdbook-version: '0.4.5'
           # mdbook-version: 'latest'
 
       - run: mdbook build

--- a/README.md
+++ b/README.md
@@ -6,8 +6,18 @@
 
 This documentation is written in [mdbook](https://github.com/rust-lang/mdBook) format.
 
+### Requirement
+
+mdBook version has to be version `0.4.5` or later due to cross site scripting vulnerability. See [official report](https://blog.rust-lang.org/2021/01/04/mdbook-security-advisory.html) from rust website.
+
 ```bash
 cargo install mdbook
+```
+
+If you already installed mdBook version `<= 0.4.4`, you need to upgrate to version 0.4.5 or later with following command.
+
+```bash
+cargo install mdbook --version 0.4.5 --force
 ```
 
 ## Build


### PR DESCRIPTION
Updated mdBook version to 0.4.5 or later due to cross-site scripting vulnerability.

https://blog.rust-lang.org/2021/01/04/mdbook-security-advisory.html
